### PR TITLE
Error en parrot

### DIFF
--- a/EASY-PWM.sh
+++ b/EASY-PWM.sh
@@ -483,7 +483,7 @@ function extra_utilities(){
   sleep 2 & while [ "$(ps a | awk '{print $1}' | grep $!)" ] ; do for X in '-' '\' '|' '/'; do echo -en "\b$X"; sleep 0.1; done; done
   echo -e "${end}\n"
 
-  declare -a required_packages=(xclip firejail caja flameshot scrub brightnessctl pamixer)
+  declare -a required_packages=(xclip firejail caja flameshot scrub brightnessctl)
  
   package_installer
 


### PR DESCRIPTION
Ya no se encuentra disponible pamixer en parrot, por lo tanto da un error y cancela la instalación.
También hay errores como root en kitty.